### PR TITLE
Replace sanitize with slug

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ Text: field4
 
 # Installation
 
-1. run `npm install` in your csv2file directory
+1. Clone or download this repo
+2. run `npm install` in your csv2file directory
 
 # Usage
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,48 @@
 # csv2file
 
-#Installation
-1. npm install
+This script converts the content of a CSV file into a folder structure with TXT files as their content ready to use in Kirby.
 
-#Usage
-1. node index.js <csvFile> [comma separated header]
+# Example Input/Output
 
-* if no "comma separated header" then will use the default headers: Date,Title,Teaser,Text
+**CSV file input:**
 
-#Example
-1. node index.js sample.csv h1,h2,h3,h4
+`field1; field2; field3; field4`
+
+**Output directories and files:**
+```
+output
+  |__ field2
+        |__ article.txt
+```
+
+The content of article.txt will result in:
+```
+Date: field1
+----
+Title: field2
+----
+Teaser: field3
+----
+Text: field4
+----
+```
+
+# Installation
+
+1. run `npm install` in your csv2file directory
+
+# Usage
+
+run `node index.js <csvFile> [comma separated header]`
+
+If no "comma separated header" is supplied, the script will use the 4 default headers: Date,Title,Teaser,Text
+The supplied headers don't neccessarily have to match the amount of fields in your CSV file.
+
+# Usage Example
+
+run `node index.js sample.csv date-published, headline, teaser-text, body-content`
+
+or using the default values:
+
+run `node index.js sample.csv`
+

--- a/index.js
+++ b/index.js
@@ -3,7 +3,6 @@ var fs = require('fs');
 var path = require('path');
 var rmdir = require('rmdir');
 var dateFormat = require('dateformat');
-var sanitize = require("sanitize-filename");
 var unidecode = require('unidecode');
 var slug = require('slug');
 

--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ var rmdir = require('rmdir');
 var dateFormat = require('dateformat');
 var sanitize = require("sanitize-filename");
 var unidecode = require('unidecode');
+var slug = require('slug');
 
 var outputDir = 'output';
 var filename = 'article.txt';
@@ -42,9 +43,8 @@ function parseCsv(csvFile, columnCount) {
 }
 
 function getFolderName(outputDir, counter, rawDirBase) {
-    var dirBase = sanitize(rawDirBase);
-    dirBase = unidecode(dirBase);
-    dirBase = dirBase.replace(/\s+/g, '-');
+    var dirBase = slug(rawDirBase, {lower: true, remove: /[.]/g}); // even though valid, remove dots completely
+    dirBase = dirBase.replace(/-$/g, ''); // strip "-" for names that end with "-"
     return path.join(outputDir, counter + '-' + dirBase);
 }
 

--- a/index.js
+++ b/index.js
@@ -87,7 +87,6 @@ function parseRow(counter, row) {
             });
         }
     });
-
 }
 
 if (process.argv[2]) {

--- a/package.json
+++ b/package.json
@@ -15,5 +15,8 @@
     "rmdir": "^1.2.0",
     "sanitize-filename": "^1.6.0",
     "unidecode": "^0.1.8"
+  },
+  "devDependencies": {
+    "slug": "^0.9.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
     "csv-parser": "^1.9.3",
     "dateformat": "^1.0.12",
     "rmdir": "^1.2.0",
-    "sanitize-filename": "^1.6.0",
     "unidecode": "^0.1.8"
   },
   "devDependencies": {


### PR DESCRIPTION
Just changed sanitize to slug, so it actually also cleans all other special characters not valid in URIs. Since the folder names will serve as the URI, it makes it much easier.
